### PR TITLE
[WIP] Creative-mode per player

### DIFF
--- a/mods/mfbase/creative/init.lua
+++ b/mods/mfbase/creative/init.lua
@@ -1,33 +1,52 @@
-if minetest.setting_getbool("creative_mode") then
-	local digtime = 5;
-	local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 256}
+local digtime = 5;
+local caps = {times = {digtime, digtime, digtime}, uses = 0, maxlevel = 256}
 
-	minetest.register_item(":", {
-		type = "none",
-		wield_image = "wieldhand.png",
-		wield_scale = {x = 1, y = 1, z = 2.5},
-		tool_capabilities = {
-			full_punch_interval = 0.5,
-			max_drop_level = 3,
-			groupcaps = {
-				crumbly = caps,
-				cracky = caps,
-				snappy = caps,
-				choppy = caps,
-				oddly_breakable_by_hand = caps,
-			},
-			damage_groups = {fleshy = 10},
-		}
-	})
+minetest.register_item("creative:hand", {
+	type = "none",
+	--wield_image = "wieldhand.png",
+	wield_image = "wieldhand.png",
+	wield_scale = {x = 1, y = 1, z = 2.5},
+	tool_capabilities = {
+		full_punch_interval = 0.5,
+		max_drop_level = 3,
+		groupcaps = {
+			crumbly = caps,
+			cracky = caps,
+			snappy = caps,
+			choppy = caps,
+			oddly_breakable_by_hand = caps,
+		},
+		damage_groups = {fleshy = 10},
+	}
+})
 
-	minetest.register_on_placenode(function(pos, newnode, placer, oldnode, itemstack)
-		return true
-	end)
-
-	function minetest.handle_node_drops(pos, drops, digger)
-		if not digger or not digger:is_player() then
-			return
+minetest.register_on_joinplayer(function(player)
+	if not player:get_attribute("default:gamemode") then -- Set initial gamemode
+		if minetest.setting_getbool("creative_mode") then
+			player:set_attribute("default:gamemode", "creative")
+		else
+			player:set_attribute("default:gamemode", "survival")
 		end
+	end
+
+	if player:get_attribute("default:gamemode") == "creative" then
+		--player:get_inventory():set_stack("hand", 1, "creative:hand")
+	else
+		player:get_inventory():set_stack("hand", 1, "")
+	end
+end)
+
+minetest.register_on_placenode(function(pos, newnode, placer, oldnode, itemstack)
+	if placer:get_attribute("default:gamemode") == "creative" then
+		return true
+	end
+end)
+
+function minetest.handle_node_drops(pos, drops, digger)
+	if not digger or not digger:is_player() then
+		return
+	end
+	if digger:get_attribute("default:gamemode") == "creative" then
 		local inv = digger:get_inventory()
 		if inv then
 			for _, item in ipairs(drops) do
@@ -39,3 +58,52 @@ if minetest.setting_getbool("creative_mode") then
 		end
 	end
 end
+
+minetest.register_chatcommand("gamemode", {
+	params = "<gamemode> [player]",
+	description = "Sets a player's game mode",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+
+		local params = {}
+		for i in string.gmatch(param, "%S+") do
+			table.insert(params, i)
+		end
+
+		-- Determine gamemode
+		if not params[1] or (params[1] ~= "survival" and params[1] ~= "creative") then
+			return false, "Please specify a valid gamemode"
+		end
+
+		-- Determine target
+		local target = nil
+		if params[2] then
+			local player = minetest.get_player_by_name(params[2])
+			if player then
+				target = player
+			else
+				return false, "Player not found"
+			end
+		else
+			if not player then
+				return false, "If this command is not ran by a player, then a player has to be specified"
+			end
+
+			target = player
+		end
+
+		target:set_attribute("default:gamemode", params[1])
+
+		for key, value in pairs(target:get_armor_groups()) do
+			print(key)
+		end
+
+		if params[1] == "creative" then
+			target:get_inventory():set_stack("hand", 1, "creative:hand")
+		else
+			target:get_inventory():set_stack("hand", 1, "")
+		end
+
+		return true, "Gamemode changed"
+	end
+})

--- a/mods/mfbase/creative/mod.conf
+++ b/mods/mfbase/creative/mod.conf
@@ -1,1 +1,1 @@
-name = minefix_creative
+name = creative

--- a/mods/mfbase/interface/creative.lua
+++ b/mods/mfbase/interface/creative.lua
@@ -1,5 +1,8 @@
+local inventorySize = 9 * 5
+
 --[[
 Registers a new creative inventory tab, useful for external mods. They will have to require this mod
+We allow this function even if the "creative" mod isn't loaded, so other mods don't have to check for that
 @categoryname = The name of the category, this name will have to be added to items
 @label = The name of the category when hovering your mouse over the tab
 @tablocation = can be top or bottom of the creative inventory
@@ -7,6 +10,14 @@ Registers a new creative inventory tab, useful for external mods. They will have
 ]]
 interface.registerCategory = function(categoryname, label, tablocation, tabimage)
 	--Example: interface.registerCategory("test", "test category", "top", "default:brick");
+
+	for category in pairs(interface.tabs) do
+		if category == categoryname then
+			minetest.log("[interface] ERROR: A category with this name already exists")
+			return
+		end
+	end
+
 	interface.tabs[categoryname] = {
 		["position"] = tablocation,
 		["label"] = label,
@@ -14,142 +25,187 @@ interface.registerCategory = function(categoryname, label, tablocation, tabimage
 	}
 end
 
-interface.initializeCreativeInventory = function(owner)
-	local owner_name = owner:get_player_name()
-
-	minetest.create_detached_inventory("creative", {
-		allow_move = function(inv, from_list, from_index, to_list, to_index, count, player)
-			return 0
-		end,
-		allow_put = function(inv, listname, index, stack, player)
-			return -1
-		end,
-		allow_take = function(inv, listname, index, stack, player)
-			--[[if player:get_player_control().sneak then
-				return stack:get_stack_max()
-			else]] -- Not used yet, we can't set an item yet the moment it is picked up from the inventory
+if minetest.get_modpath("creative") ~= nil then -- Initializing the creative inventory
+	interface.registerCreativeInventory = function(player)
+		minetest.create_detached_inventory("creative_" .. player:get_player_name(), {
+			allow_move = function(inv, from_list, from_index, to_list, to_index, count, player)
+				return 0
+			end,
+			allow_put = function(inv, listname, index, stack, player)
 				return -1
-			--end
-		end,
-		on_move = function(inv, from_list, from_index, to_list, to_index, count, player)
-			return -1
-		end,
-		on_put = function(inv, listname, index, stack, player)
-			return
-		end,
-		on_take = function(inv, listname, index, stack, player)
+			end,
+			allow_take = function(inv, listname, index, stack, player)
+				--[[if player:get_player_control().sneak then
+					return stack:get_stack_max()
+				else]] -- Not used yet, we can't set an item yet the moment it is picked up from the inventory
+					return -1
+				--end
+			end,
+			on_move = function(inv, from_list, from_index, to_list, to_index, count, player)
+				return -1
+			end,
+			on_put = function(inv, listname, index, stack, player)
+				return
+			end,
+			on_take = function(inv, listname, index, stack, player)
 
-		end,
-	})
-end
-
-interface.fillCreativeInventory = function(player, tab)
-	local inventory = minetest.get_inventory({type="detached", name="creative"})
-	inventory:set_size("main", 0)
-
-	local creative_list = {};
-	for name, def in pairs(minetest.registered_items) do
-		if def.category ~= nil and tab == def.category then
-			table.insert(creative_list, name)
-		elseif def.category ~= nil and tab == "search" then -- We want the search tab to have all items by default
-
-			table.insert(creative_list, name)
-		end
+			end,
+		})
 	end
 
-	table.sort(creative_list)
-	local creative_list_filledup = 50 - (#creative_list % 50) + #creative_list -- Fill up empty spots
+	interface.fillCreativeInventory = function(player, tab, startIndex)
+		local inventory = minetest.get_inventory({type = "detached", name = "creative_" .. player:get_player_name()})
+		inventory:set_size("main", 0) -- First we'll empty whatever was in the inventory before by setting inventory size to 0, we'll resize it later
 
-	if #creative_list ~= 0 then
-		inventory:set_size("main", creative_list_filledup)
-	else
-		inventory:set_size("main", creative_list_filledup) --Set it to 1 big so the game won't complain that the 'main' list doesn't exist
-	end
-
-	for key, itemstring in ipairs(creative_list) do
-		inventory:add_item("main", ItemStack(itemstring))
-	end
-
-	interface.creative_inventory_size = #creative_list
-end
-
-interface.createCreativeInventory = function(player, tab, startIndex, pageNumber)
-	local inventory = minetest.get_inventory({type="detached", name="creative"})
-
-	if startIndex < 0 then
-		startIndex = 0
-	end
-
-	pageNumber = math.floor(pageNumber) or 1
-	local pagemax = math.floor((interface.creative_inventory_size - 1) / (9 * 5) + 1)
-	local slider_height = 4 / pagemax
-	local slider_pos = slider_height * (pageNumber - 1) + 2.25
-
-	local activeTab, tabsTop, tabsBottom = "", "", ""
-	local tabsTopButtonX, tabsBottomButtonX = -0.1, -0.1
-	for key, value in pairs(interface.tabs) do
-		if value.position == "top" then
-			if key == tab then
-				activeTab = "image[" .. tabsTopButtonX - 0.17 ..",-0.30;1.27,1.65;interface_creative_tab_active.png]"
-			else
-				tabsTop = tabsTop .. "image[" .. tabsTopButtonX - 0.15 .. ",-0.15;1.27,1.27;interface_creative_tab_inactive.png]"
+		local creative_list_full = {};
+		for name, def in pairs(minetest.registered_items) do
+			if def.category ~= nil and (tab == def.category or tab == "search") then
+				table.insert(creative_list_full, name)
 			end
-			tabsTop = tabsTop .. "item_image_button[" .. tabsTopButtonX - 0.075 .. ",0;1,1;" .. value.image .. ";" .. key .. ";]"
-			tabsTopButtonX = tabsTopButtonX + 1.28
+		end
+
+		local creative_list_selection = {};
+		local iteration = 0
+		for _, value in pairs(creative_list_full) do
+			if iteration >= startIndex + inventorySize then
+				break
+			elseif iteration >= startIndex then
+				table.insert(creative_list_selection, value)
+			end
+
+			iteration = iteration + 1
+		end
+
+		local creative_list_filledup = inventorySize - (#creative_list_selection % inventorySize) + #creative_list_selection -- Fill up empty spots
+		inventory:set_size("main", inventorySize) -- Set inventory size back to the correct size
+
+		for key, itemstring in ipairs(creative_list_selection) do
+			inventory:add_item("main", ItemStack(itemstring))
+		end
+
+
+
+		interface.creative_inventory_size = #creative_list_full
+	end
+
+	-- Actually sets the inventory for the specified player
+	interface.createCreativeInventory = function(player, tab, startIndex, pageNumber)
+		if startIndex < 0 then
+			startIndex = 0
+		end
+
+		pageNumber = pageNumber or 0
+		local pagemax = math.floor(math.floor((interface.creative_inventory_size / 9) / 5 + 1))
+		local slider_height = 4 / pagemax
+		local slider_pos = slider_height * (pageNumber) + 2.25
+
+		local activeTab, tabsTop, tabsBottom = "", "", ""
+		local tabsTopButtonX, tabsBottomButtonX = -0.1, -0.1
+		for key, value in pairs(interface.tabs) do
+			if value.position == "top" then
+				if key == tab then
+					activeTab = "image[" .. tabsTopButtonX - 0.17 ..",-0.30;1.27,1.65;interface_creative_tab_active.png]"
+				else
+					tabsTop = tabsTop .. "image[" .. tabsTopButtonX - 0.15 .. ",-0.15;1.27,1.27;interface_creative_tab_inactive.png]"
+				end
+				tabsTop = tabsTop .. "item_image_button[" .. tabsTopButtonX - 0.075 .. ",0;1,1;" .. value.image .. ";" .. key .. ";]"
+				tabsTopButtonX = tabsTopButtonX + 1.28
+			else
+				if key == tab then
+					activeTab = "image[" .. tabsBottomButtonX - 0.17 ..",8;1.27,1.65;interface_creative_tab_active.png^[transformfy]]"
+				else
+					tabsTop = tabsTop .. "image[" .. tabsBottomButtonX - 0.15 .. ",8.175;1.27,1.27;interface_creative_tab_inactive.png^[transformfy]]"
+				end
+				tabsBottom = tabsBottom .. "item_image_button[" .. tabsBottomButtonX - 0.075 .. ",8.3;1,1;" .. value.image .. ";" .. key .. ";]"
+				tabsBottomButtonX = tabsBottomButtonX + 1.28
+			end
+		end
+
+		local searchTab, inventoryTab
+		if tab == "search" then
+			searchTab = "image[10.18,-0.30;1.27,1.65;interface_creative_tab_active.png]"
 		else
-			if key == tab then
-				activeTab = "image[" .. tabsBottomButtonX - 0.17 ..",8;1.27,1.65;interface_creative_tab_active.png^[transformfy]]"
-			else
-				tabsTop = tabsTop .. "image[" .. tabsBottomButtonX - 0.15 .. ",8.175;1.27,1.27;interface_creative_tab_inactive.png^[transformfy]]"
+			searchTab = "image[10.2,-0.15;1.25,1.27;interface_creative_tab_inactive.png]"
+		end
+		searchTab = searchTab .. "item_image_button[10.3,0;1,1;default:wood_oak;search;]" -- Use a temporary item for the search tab for now
+
+		if tab == "inventory" then
+			inventoryTab = "image[10.18,8;1.27,1.65;interface_creative_tab_active.png^[transformfy]]"
+		else
+			inventoryTab = "image[10.2,8.175;1.25,1.27;interface_creative_tab_inactive.png^[transformfy]]"
+		end
+		inventoryTab = inventoryTab .. "item_image_button[10.3,8.3;1,1;default:chest;inventory;]"
+
+		local background, itemlist, slider
+		if tab == "inventory" then
+			background = "background[-0.2,1;11.5,7.25;gui_formbg.png]"
+			itemlist = "list[current_player;main;0,3.75;9,3;9]"
+			slider = ""
+		else
+			background = "background[-0.2,1;11.5,7.25;gui_formbg.png]"
+			itemlist = "list[detached:creative_" .. player:get_player_name() .. ";main;0,1.74;9,5;]"
+			slider = "image_button[10,1.76;0.85,0.6;interface_creative_up.png;creative_prev;]" ..
+			"image[10," .. tostring(slider_pos) .. ";0.75," .. tostring(slider_height) .. ";interface_creative_slider.png]" ..
+			"image_button[10,6.13;0.85,0.6;interface_creative_down.png;creative_next;]"
+		end
+
+		local formspec = "size[12,9.3]" ..
+			background ..
+			"bgcolor[#080808BB;true]" ..
+			"label[-5,-5;Building Blocks]" ..
+			activeTab ..
+			tabsTop ..
+			searchTab ..
+			itemlist ..
+			slider ..
+			"list[current_player;main;0,7;9,1;]" ..
+			tabsBottom ..
+			inventoryTab ..
+			"field[0,0;0,0;active_tab;;" .. (tab or "building") .. "]" ..
+			"field[0,0;0,0;page;;" .. (tostring(pageNumber) or 0) .. "]"
+		player:set_inventory_formspec(formspec)
+	end
+
+	--Gets called if a button is pressed in a player's inventory form, or the inventory is opened
+	--If it returns true, remaining functions (other mods, etc) are not called
+	interface.handleCreativeInventory = function(player, formname, fields)
+		fields.page = tonumber(fields.page)
+
+		local tab = nil;
+		for key, value in pairs(fields) do
+			if interface.tabs[key] then
+				tab = key
 			end
-			tabsBottom = tabsBottom .. "item_image_button[" .. tabsBottomButtonX - 0.075 .. ",8.3;1,1;" .. value.image .. ";" .. key .. ";]"
-			tabsBottomButtonX = tabsBottomButtonX + 1.28
 		end
-	end
 
-	local searchTab, inventoryTab
-	if tab == "search" then
-		searchTab = "image[10.18,-0.30;1.27,1.65;interface_creative_tab_active.png]"
-	else
-		searchTab = "image[10.2,-0.15;1.25,1.27;interface_creative_tab_inactive.png]"
-	end
-	searchTab = searchTab .. "item_image_button[10.3,0;1,1;default:wood_oak;search;]" -- Use a temporary item for the search tab for now
-
-	if tab == "inventory" then
-		inventoryTab = "image[10.18,8;1.27,1.65;interface_creative_tab_active.png^[transformfy]]"
-	else
-		inventoryTab = "image[10.2,8.175;1.25,1.27;interface_creative_tab_inactive.png^[transformfy]]"
-	end
-	inventoryTab = inventoryTab .. "item_image_button[10.3,8.3;1,1;default:chest;inventory;]"
-
-	local background, itemlist, slider
-	if tab == "inventory" then
-		background = "background[-0.2,1;11.5,7.25;gui_formbg.png]"
-		itemlist = "list[current_player;main;0,3.75;9,3;9]"
-		slider = ""
-	else
-		background = "background[-0.2,1;11.5,7.25;gui_formbg.png]"
-		itemlist = "list[detached:creative;main;0,1.74;10,5;" .. tostring(startIndex) .. "]"
-		slider = "image_button[10,1.76;0.85,0.6;interface_creative_up.png;creative_prev;]" ..
-		"image[10," .. tostring(slider_pos) .. ";0.75," .. tostring(slider_height) .. ";interface_creative_slider.png]" ..
-		"image_button[10,6.13;0.85,0.6;interface_creative_down.png;creative_next;]"
-	end
-
-	local formspec = "size[12,9.3]" ..
-		background ..
-		"bgcolor[#080808BB;true]" ..
-		"label[-5,-5;Building Blocks]" ..
-		activeTab ..
-		tabsTop ..
-		searchTab ..
-		itemlist ..
-		slider ..
-		"list[current_player;main;0,7;9,1;]" ..
-		tabsBottom ..
-		inventoryTab
-
-		if pageNumber ~= nil then
-			formspec = formspec .. "p" .. tostring(pageNumber)
+		if tab and tab ~= fields.active_tab then
+			fields.page = 0
 		end
-	player:set_inventory_formspec(formspec)
+
+		if not tab then
+			if fields.inventory then
+				tab = "inventory"
+			elseif fields.search then
+				tab = "search"
+			else -- fields.creative_prev, fields.creative_next, everything else
+				tab = fields.active_tab
+			end
+		end
+
+		if fields.creative_prev and fields.page > 0 then
+			fields.page = fields.page - 1
+		elseif fields.creative_next and (fields.page + 1) * inventorySize < interface.creative_inventory_size then
+			fields.page = fields.page + 1
+		end
+
+		local startIndex = (fields.page or 0) * inventorySize -- (fields.page or 0) is needed as fields.page is not set when closing the inventory
+--		print(fields.page .. " " .. startIndex)
+
+
+		if tab ~= "inventory" then
+			interface.fillCreativeInventory(player, tab, startIndex)
+		end
+
+		interface.createCreativeInventory(player, tab, startIndex, fields.page)
+	end
 end

--- a/mods/mfbase/interface/depends.txt
+++ b/mods/mfbase/interface/depends.txt
@@ -1,3 +1,4 @@
+creative?
 status?
 hunger?
 experience?

--- a/mods/mfbase/interface/survival.lua
+++ b/mods/mfbase/interface/survival.lua
@@ -1,7 +1,7 @@
-interface.createSurvivalInventory = function(player)
-	local inventory = minetest.get_inventory({type="detached", name="survival"})
+formspec = ""
 
-	local formspec = "size[9,8.5]"..
+interface.createSurvivalInventory = function(player)
+	formspec = "size[9,8.5]"..
 		"bgcolor[#080808BB;true]" ..
 		"background[0,0;9,8.5;gui_formbg.png;true]" ..
 		"label[5,0.1;Crafting]" ..
@@ -12,49 +12,53 @@ interface.createSurvivalInventory = function(player)
 		"list[current_player;main;0,7.50;9,1;]"
 
 	player:set_inventory_formspec(formspec)
+end
 
-	local timer = 0
-	minetest.register_globalstep(function(dtime)
-		timer = timer + dtime
+local timer = 0
+minetest.register_globalstep(function(dtime)
+	timer = timer + dtime
 
-		if timer > 1 then --Only update statuses display every second
-			timer = 0
+	if timer > 1 then --Only update statuses display every second
+		timer = 0
 
-			local status_formspec = ""
-			local bar_height = 0
-			if minetest.get_modpath("status") ~= nil then
-				for key, value in pairs(statuses) do --TODO: Needs sorting by status with longest duration left first
-					if status.player_has_status_by_id(key, player) then
-						local duration = status.get_player_status_length_by_id(key, player)
-						duration = tostring(math.floor(duration / 60)) .. ":" .. tostring(duration % 60)
+		for key, player in ipairs(minetest.get_connected_players()) do
+			if player:get_attribute("default:gamemode") == "survival" then
+				player:set_inventory_formspec(formspec)
+				
+				local status_formspec = ""
+				local bar_height = 0
+				if minetest.get_modpath("status") ~= nil then
+					for key, value in pairs(statuses) do --TODO: Needs sorting by status with longest duration left first
+						if status.player_has_status_by_id(key, player) then
+							local duration = status.get_player_status_length_by_id(key, player)
+							duration = tostring(math.floor(duration / 60)) .. ":" .. tostring(duration % 60)
 
-						status_formspec = status_formspec ..
-						"background[0," .. bar_height .. ";5.5,1.5;default_status_bar_bg.png]" ..
-						"image[0.25," .. bar_height + 0.25 .. ";1,1;" .. value.image .. "]" ..
-						"label[1.25," .. bar_height + 0.1 .. ";" .. value.display_name .. "]" ..
-						"label[1.25," .. bar_height + 0.5 .. ";" .. duration .. "]"
+							status_formspec = status_formspec ..
+							"background[0," .. bar_height .. ";5.5,1.5;default_status_bar_bg.png]" ..
+							"image[0.25," .. bar_height + 0.25 .. ";1,1;" .. value.image .. "]" ..
+							"label[1.25," .. bar_height + 0.1 .. ";" .. value.display_name .. "]" ..
+							"label[1.25," .. bar_height + 0.5 .. ";" .. duration .. "]"
 
-						bar_height = bar_height + 1.75
+							bar_height = bar_height + 1.75
+						end
+					end
+
+					if string.len(status_formspec) > 0 then -- Bigger than 0 means the player has a status applied
+						local formspec = "size[15,8.5]"..
+							"bgcolor[#080808BB;true]" ..
+							status_formspec ..
+							"background[5.75,0;9.5,8.75;gui_formbg.png]" ..
+							"label[11,0.1;Crafting]" ..
+							"list[current_player;craft;11,0.5;2,2;]"..
+							"image[13,1;1,1;gui_furnace_arrow_bg.png^[transformR270]" ..
+							"list[current_player;craftpreview;14,1;1,1;]"..
+							"list[current_player;main;6,4.25;9,3;9]" ..
+							"list[current_player;main;6,7.50;9,1;]"
+
+						player:set_inventory_formspec(formspec)
 					end
 				end
 			end
-
-			if string.len(status_formspec) > 0 then -- Bigger than 0 means the player has a status applied
-				local formspec = "size[15,8.5]"..
-					"bgcolor[#080808BB;true]" ..
-					status_formspec ..
-					"background[5.75,0;9.5,8.75;gui_formbg.png]" ..
-					"label[11,0.1;Crafting]" ..
-					"list[current_player;craft;11,0.5;2,2;]"..
-					"image[13,1;1,1;gui_furnace_arrow_bg.png^[transformR270]" ..
-					"list[current_player;craftpreview;14,1;1,1;]"..
-					"list[current_player;main;6,4.25;9,3;9]" ..
-					"list[current_player;main;6,7.50;9,1;]"
-
-				player:set_inventory_formspec(formspec)
-			else
-				player:set_inventory_formspec(formspec)
-			end
 		end
-	end)
-end
+	end
+end)

--- a/mods/mfbase/physics/init.lua
+++ b/mods/mfbase/physics/init.lua
@@ -7,29 +7,31 @@ local players = {}
 minetest.register_on_joinplayer(function(player)
 	players[player:get_player_name()] = {}
     minetest.register_globalstep(function(dtime)
-        -- Jump tweak
-        if player:get_player_control().jump then
-            minetest.after(0.18, function()
-                player:set_physics_override({
-                    gravity = gravity_rate,
-                })
-            end)
-        end
+		if player:is_player() then
+	        -- Jump tweak
+	        if player:get_player_control().jump then
+	            minetest.after(0.18, function()
+	                player:set_physics_override({
+	                    gravity = gravity_rate,
+	                })
+	            end)
+	        end
 
-        -- Sprinting
-        if player:get_player_control().aux1 and player:get_player_control().up then
-            player:set_physics_override({
-                speed = sprint_speed
-            })
+	        -- Sprinting
+	        if player:get_player_control().aux1 and player:get_player_control().up then
+	            player:set_physics_override({
+	                speed = sprint_speed
+	            })
 
-			players[player:get_player_name()].sprinting = true
-        else
-            player:set_physics_override({
-                speed = 1.0
-            })
+				players[player:get_player_name()].sprinting = true
+	        else
+	            player:set_physics_override({
+	                speed = 1.0
+	            })
 
-			players[player:get_player_name()].sprinting = false
-        end
+				players[player:get_player_name()].sprinting = false
+	        end
+		end
     end)
 end)
 


### PR DESCRIPTION
This PR is making creative-mode entirely per player (where it's per world right now), so on servers individual people can become creative or survival mode instead of all of them. Where possible I'm trying to make it gamemode "independent". Meaning it can later be extended to support adventure and spectator mode as well.

Things to do:

- [x] Add command to switch between gamemodes
- [x] Making inventories per player
- [ ] Enable/disable hud per player
- [ ] Enable/disable damager per player (also ignore the current `enable_damage` setting) (as of yet impossible)
- [ ] Allow per player creative block breaking
    - [x] Bare hand
    - [ ] With tools and/or items in the hand (as of yet impossible)