### PR TITLE
Added the complete set of valid base blocks for Sugar Cane

### DIFF
--- a/mods/mfbase/farming/builtin.lua
+++ b/mods/mfbase/farming/builtin.lua
@@ -124,7 +124,7 @@ farming.register_block("farming:reeds", {
 	drop = "farming:reeds",
 	texture = {"default_papyrus.png"},
 	inventory_image = "farming_reeds.png",
-	baseblocks = {"default:sand", "farming:reeds"},
+	baseblocks = {"default:sand", "default:sand_red", "default:dirt", "default:dirt_coarse", "default:dirt_with_grass", "farming:reeds"},
 	maxheight = 3,
 	allowneighbours = true,
 	requirewater = true


### PR DESCRIPTION
This PR adds _Red Sand_, _Dirt_, _Coarse Dirt_, and _Grass_ as valid base blocks for Sugar Cane, so that it matches the expected behaviour from Minecraft.